### PR TITLE
New `replace_NaN_with` and `replace_NaT_with` options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
 
 before_install:
   # (a) linux dependencies
-  - sudo apt-get install pandoc
   - sudo apt-get install ant
   - sudo apt-get install ant-optional
 
@@ -27,6 +26,8 @@ install:
   # needs to be installed beforehand
   - pip install setuptools_scm
   - python ci_tools/py_install.py pip ci_tools/requirements-pip.txt
+  # this does not work anymore on python 2 so lets only do it when needed
+  - if [ "${TRAVIS_PYTHON_VERSION}" = "3.5" ]; then pip install mkdocs-material mkdocs; fi;
   # travis-specific installs
   - pip install PyGithub  # for ci_tools/github_release.py
   - pip install codecov  # See https://github.com/codecov/example-python.

--- a/azmlclient/base.py
+++ b/azmlclient/base.py
@@ -189,6 +189,8 @@ def execute_rr(api_key,                                # type: str
                output_names=None,                      # type: List[str]
                only_keep_selected_output_names=False,  # type: bool
                use_swagger_format=False,               # type: bool
+               replace_NaN_with=None,                  # type: Any
+               replace_NaT_with=None,                  # type: Any
                requests_session=None                   # type: requests.Session
                ):
     # type: (...) -> Dict[str, pd.DataFrame]
@@ -215,7 +217,8 @@ def execute_rr(api_key,                                # type: str
                          "`output_names`")
 
     # 0- Create the generic request-response client
-    rr_client = RequestResponseClient(requests_session=requests_session, use_swagger_format=use_swagger_format)
+    rr_client = RequestResponseClient(requests_session=requests_session, use_swagger_format=use_swagger_format,
+                                      replace_NaN_with=replace_NaN_with, replace_NaT_with=replace_NaT_with)
 
     # 1- Create the query body
     request_body = rr_client.create_request_body(inputs, params)
@@ -456,8 +459,10 @@ class RequestResponseClient(BaseHttpClient):
     """
 
     def __init__(self,
-                 requests_session=None,    # type: requests.Session
-                 use_swagger_format=False  # type: bool
+                 requests_session=None,     # type: requests.Session
+                 use_swagger_format=False,  # type: bool
+                 replace_NaN_with=None,     # type: Any
+                 replace_NaT_with=None,     # type: Any
                  ):
         """
         Constructor with an optional `requests.Session` to use for subsequent calls.
@@ -470,6 +475,8 @@ class RequestResponseClient(BaseHttpClient):
         """
         # save swagger format
         self.use_swagger_format = use_swagger_format
+        self.replace_NaN_with = replace_NaN_with
+        self.replace_NaT_with = replace_NaT_with
 
         # super constructor
         super(RequestResponseClient, self).__init__(requests_session=requests_session)
@@ -493,7 +500,8 @@ class RequestResponseClient(BaseHttpClient):
             params_df_or_dict = {}
 
         # inputs
-        inputs = dfs_to_azmltables(input_df_dict, swagger_format=self.use_swagger_format)
+        inputs = dfs_to_azmltables(input_df_dict, swagger_format=self.use_swagger_format,
+                                   replace_NaN_with=self.replace_NaN_with, replace_NaT_with=self.replace_NaT_with)
 
         # params
         if isinstance(params_df_or_dict, dict):

--- a/azmlclient/base.py
+++ b/azmlclient/base.py
@@ -121,7 +121,7 @@ def parse_proxy_info(proxy_url
 def create_session_for_proxy(http_proxyhost,                  # type: str
                              http_proxyport,                  # type: int
                              https_proxyhost=None,            # type: str
-                             https_proxyport=None,            # type: str
+                             https_proxyport=None,            # type: int
                              use_http_for_https_proxy=False,  # type: bool
                              ssl_verify=None
                              ):

--- a/azmlclient/base_databinding.py
+++ b/azmlclient/base_databinding.py
@@ -459,6 +459,12 @@ def json_to_azmltable(json_str  # type: str
     return json.loads(json_str, object_pairs_hook=OrderedDict)
 
 
+if sys.version_info >= (3, 0, 0):
+    PRIM_TYPES = (int, str, bool)
+else:
+    PRIM_TYPES = (int, str, bool, eval('long'))
+
+
 def to_jsonable_primitive(obj,
                           replace_NaN_with=None,  # type: Any
                           replace_NaT_with=None   # type: Any
@@ -476,7 +482,7 @@ def to_jsonable_primitive(obj,
             return replace_NaN_with or obj
         else:
             return obj
-    elif isinstance(obj, (int, str, bool)):  # , dict, list, tuple, set
+    elif isinstance(obj, PRIM_TYPES):  # , dict, list, tuple, set
         return obj
     else:
         return azml_json_serializer(obj, replace_NaT_with=replace_NaT_with)

--- a/azmlclient/tests/databinding/test_databinding.py
+++ b/azmlclient/tests/databinding/test_databinding.py
@@ -16,28 +16,71 @@ def case(case_data):
     return case_data.get()
 
 
-def test_df_to_azmltable(case  # type: DataBindingTestCase
-                         ):
+@pytest.mark.parametrize("swagger_mode_on", [False, True], ids="swagger_mode_on={}".format)
+@pytest.mark.parametrize("replace_NaN_with", [None, "null"], ids="replace_NaN_with={}".format)
+@pytest.mark.parametrize("replace_NaT_with", [None, "null"], ids="replace_NaT_with={}".format)
+def test_df_to_azmltable(case,  # type: DataBindingTestCase
+                         swagger_mode_on, replace_NaN_with, replace_NaT_with):
     """ Tests that a dataframe can be converted to azureml representation (as a dict) and back. """
 
-    azt = df_to_azmltable(case.df)
-    df2 = azmltable_to_df(azt)
+    azt = df_to_azmltable(case.df, swagger_format=swagger_mode_on,
+                          replace_NaN_with=replace_NaN_with, replace_NaT_with=replace_NaT_with)
+    df2 = azmltable_to_df(azt, swagger_mode=swagger_mode_on)
 
     assert_frame_equal(case.df, df2)
 
 
+def _is_datetime_dtype(series):
+    try:
+        series.dt
+    except AttributeError:
+        return False
+    else:
+        return True
+
+
 @pytest.mark.parametrize('swagger_mode_on', [False, True], ids="swagger={}".format)
-def test_df_to_json(swagger_mode_on,
+@pytest.mark.parametrize("replace_NaN_with", [None, "null"], ids="replace_NaN_with={}".format)
+@pytest.mark.parametrize("replace_NaT_with", [None, "null"], ids="replace_NaT_with={}".format)
+def test_df_to_json(swagger_mode_on, replace_NaN_with, replace_NaT_with,
                     case  # type: DataBindingTestCase
                     ):
     """ Tests that a dataframe can be converted to azureml json representation and back. """
 
-    azt = df_to_azmltable(case.df, swagger_format=swagger_mode_on)
+    nan_cells = []
+    nat_cells = []
+    for col_index, col in enumerate(case.df):
+        nan_indices = case.df.index[case.df[col].isnull()].to_list()
+        if len(nan_indices) > 0:
+            if _is_datetime_dtype(case.df[col]):
+                nat_cells.append((col, col_index, nan_indices))
+            else:
+                nan_cells.append((col, col_index, nan_indices))
+
+    azt = df_to_azmltable(case.df, swagger_format=swagger_mode_on, replace_NaN_with=replace_NaN_with,
+                          replace_NaT_with=replace_NaT_with)
+
+    # check nan/nat conversion
+    for col, col_index, nan_indices in nan_cells:
+        for i in nan_indices:
+            if swagger_mode_on:
+                assert azt[i][col] == replace_NaN_with or "nan"
+            else:
+                assert azt['Values'][i][col_index] == replace_NaN_with or "nan"
+
+    for col, col_index, nan_indices in nat_cells:
+        for i in nan_indices:
+            if swagger_mode_on:
+                assert azt[i][col] == replace_NaT_with or "NaT"
+            else:
+                assert azt['Values'][i][col_index] == replace_NaT_with or "NaT"
+
     az_json_df = azmltable_to_json(azt)
 
     print("Converted df -> json:")
     print(az_json_df)
-    assert json.loads(az_json_df) == json.loads(case.get_df_json(swagger_mode_on=swagger_mode_on))
+    if replace_NaN_with is None and replace_NaT_with is None:
+        assert json.loads(az_json_df) == json.loads(case.get_df_json(swagger_mode_on=swagger_mode_on))
 
     azt2 = json_to_azmltable(az_json_df)
     df2 = azmltable_to_df(azt2)

--- a/ci_tools/requirements-pip.txt
+++ b/ci_tools/requirements-pip.txt
@@ -28,5 +28,5 @@ pytest-html==1.9.0  # otherwise requires pytest 5
 xunitparser
 
 # --- to generate the doc (see .travis)
-mkdocs-material  #==3.3.0
-mkdocs  # ==1.0.4  # this is to prevent a version non-compliant with mkdocs-material to be installed.
+# mkdocs-material  #==3.3.0
+# mkdocs  # ==1.0.4  # this is to prevent a version non-compliant with mkdocs-material to be installed.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.5.0 - New `replace_NaN_with` and `replace_NaT_with` options
+
+New `replace_NaN_with` and `replace_NaT_with` options to control how `NaN` and `NaT` get converted. Fixes [#11](https://github.com/smarie/python-azureml-client/issues/11)
+
 ### 2.4.0 - new helper method + doc
 
 New method `create_response_body` in `RequestResponseClient`. Updated doc to show how these goodies can be used.

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,14 @@ outputs = execute_bes(api_key, base_url,
                       inputs=inputs, params=params, output_names=output_names)
 ```
 
+### Formatting options
+
+`execute_bes` provides several options to control how dataframes are converted to json in the request payloads:
+
+ - `swagger_format` is a boolean (default `False`) enabling the more verbose "swagger" (= json objects) format
+ - `replace_NaN_with` and `replace_NaT_with` control how `NaN` and `NaT` are converted
+
+
 ### Debug and proxies
 
 Users may wish to create a requests session object using the helper method provided, in order to override environment variable settings for HTTP requests. For example to use [`Fiddler`](https://www.telerik.com/fiddler) as a proxy to debug the web service calls: 

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ See:
 https://packaging.python.org/en/latest/distributing.html
 https://github.com/pypa/sampleproject
 """
-from six import raise_from
 from os import path
 
+import pkg_resources
 from setuptools import setup, find_packages
 
 here = path.abspath(path.dirname(__file__))
@@ -14,15 +14,14 @@ here = path.abspath(path.dirname(__file__))
 INSTALL_REQUIRES = ['functools32;python_version<"3.3"', 'valid8>=2.1', 'requests', 'jinja2',
                     'decopatch', 'makefun', 'yamlable>=0.7', 'autoclass>=1.15,<2', 'numpy', 'pandas']
 DEPENDENCY_LINKS = []
-SETUP_REQUIRES = ['pytest-runner', 'setuptools_scm', 'pypandoc', 'pandoc']
+SETUP_REQUIRES = ['pytest-runner', 'setuptools_scm']
 TESTS_REQUIRE = ['pytest', 'pytest-logging', 'pytest-cases', 'cherrypy', 'azure-storage==0.33.0']
 EXTRAS_REQUIRE = {}
 
-# simple check
-try:
-    from setuptools_scm import get_version
-except Exception as e:
-    raise_from(Exception('Required packages for setup not found. Please install `setuptools_scm`'), e)
+# (1) check required versions (from https://medium.com/@daveshawley/safely-using-setup-cfg-for-metadata-1babbe54c108)
+pkg_resources.require("setuptools>=39.2")
+pkg_resources.require("setuptools_scm")
+
 
 # ************** ID card *****************
 DISTNAME = 'azmlclient'
@@ -33,6 +32,7 @@ URL = 'https://github.com/smarie/python-azureml-client'
 LICENSE = 'MIT'
 LICENSE_LONG = 'License :: OSI Approved :: MIT License'
 
+from setuptools_scm import get_version
 version_for_download_url = get_version()
 DOWNLOAD_URL = URL + '/tarball/' + version_for_download_url
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ here = path.abspath(path.dirname(__file__))
 
 # *************** Dependencies *********
 INSTALL_REQUIRES = ['functools32;python_version<"3.3"', 'valid8>=2.1', 'requests', 'jinja2',
-                    'decopatch', 'makefun', 'yamlable>=0.7', 'autoclass>=1.15,<2', 'numpy', 'pandas']
+                    'decopatch', 'makefun', 'yamlable>=0.7', 'autoclass>=1.15', 'numpy', 'pandas']
 DEPENDENCY_LINKS = []
 SETUP_REQUIRES = ['pytest-runner', 'setuptools_scm']
 TESTS_REQUIRE = ['pytest', 'pytest-logging', 'pytest-cases', 'cherrypy', 'azure-storage==0.33.0']


### PR DESCRIPTION
New `replace_NaN_with` and `replace_NaT_with` options to control how `NaN` and `NaT` get converted. Fixes [#11](https://github.com/smarie/python-azureml-client/issues/11)